### PR TITLE
[PR-1268] Follow up article on TTH in GHC 9

### DIFF
--- a/Introduction to Template Haskell/article.md
+++ b/Introduction to Template Haskell/article.md
@@ -329,6 +329,7 @@ generateTupleClass size = do
     r = mkName "r"
 
     -- class TupleX t r | t -> r where
+    -- In GHC 9: cDecl = ClassD [] className [PlainTV t (), PlainTV r ()] [FunDep [t] [r]] [mDecl]
     cDecl = ClassD [] className [PlainTV t, PlainTV r] [FunDep [t] [r]] [mDecl]
     --   _X :: t -> r
     mDecl = SigD methodName (AppT (AppT ArrowT (VarT t)) (VarT r))
@@ -340,7 +341,8 @@ For the declaration of the class, we use the `ClassD` constructor with the follo
 
 * `[] :: Ctx` — An empty array of constraints, since we don't impose further restrictions on our types.
 * `className :: Name` — The name of the class being declared.
-* `[PlainTV t, PlainTV r] :: [TyVarBndr ()]` — The bindings of our typeclass, which are `t` and `r`.
+* `[PlainTV t, PlainTV r] :: [TyVarBndr]` — The bindings of our typeclass, which are `t` and `r`.
+  * Note: In GHC 9, use `[PlainTV t (), PlainTV r ()] :: [TyVarBndr ()]` instead.
 * `[FunDep [t] [r]] :: [FunDep]` — A functional dependency of the format `t -> r`.
 * `[mDecl] :: [Dec]` — Our class declarations, containing `_X`, a method of type `t -> r`.
 

--- a/Introduction to Template Haskell/article.md
+++ b/Introduction to Template Haskell/article.md
@@ -134,7 +134,7 @@ What is going on with the `$compose`? This is a _splice_, and it allows us to us
 
 Since Template Haskell is evaluated during compile time, if we replace `x` with a variable that was not bound, such as `z`, we get a `Variable not in scope: z` error instead during the splice generation. Any malformed expressions will be reported like any other regular Haskell expression. In other words, we analyze a Template Haskell declaration as if it was any other ordinary Haskell declaration.
 
-Keep in mind that in GHC 8, the usage of splices may require parentheses or not. For instance, if `compose` came from a qualified import, then you'd need to write `$(Foo.compose)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
+Keep in mind that before GHC 9, the usage of splices may require parentheses or not. For instance, if `compose` came from a qualified import, then you'd need to write `$(Foo.compose)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
 
 ### Stage restriction
 

--- a/Introduction to Template Haskell/article.md
+++ b/Introduction to Template Haskell/article.md
@@ -134,6 +134,8 @@ What is going on with the `$compose`? This is a _splice_, and it allows us to us
 
 Since Template Haskell is evaluated during compile time, if we replace `x` with a variable that was not bound, such as `z`, we get a `Variable not in scope: z` error instead during the splice generation. Any malformed expressions will be reported like any other regular Haskell expression. In other words, we analyze a Template Haskell declaration as if it was any other ordinary Haskell declaration.
 
+Keep in mind that in GHC 8, the usage of splices may require parentheses or not. For instance, if `compose` came from a qualified import, then you'd need to write `$(Foo.compose)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
+
 ### Stage restriction
 
 One caveat of splices exists on where they may be defined and used within some source file. To visualize the problem, we will create a new file called `Main.hs` with the following:

--- a/Introduction to Template Haskell/article.md
+++ b/Introduction to Template Haskell/article.md
@@ -329,8 +329,9 @@ generateTupleClass size = do
     r = mkName "r"
 
     -- class TupleX t r | t -> r where
-    -- In GHC 9: cDecl = ClassD [] className [PlainTV t (), PlainTV r ()] [FunDep [t] [r]] [mDecl]
     cDecl = ClassD [] className [PlainTV t, PlainTV r] [FunDep [t] [r]] [mDecl]
+    -- In GHC 9: cDecl = ClassD [] className [PlainTV t (), PlainTV r ()] [FunDep [t] [r]] [mDecl]
+
     --   _X :: t -> r
     mDecl = SigD methodName (AppT (AppT ArrowT (VarT t)) (VarT r))
 ```

--- a/Typed Template Haskell/article.md
+++ b/Typed Template Haskell/article.md
@@ -1,4 +1,4 @@
-Welcome to our second post on Template Haskell! 
+Welcome to our second post on Template Haskell!
 
 Today we will take a quick look at typed Template Haskell. This article assumes some familiarity with Template Haskell (TH) already. If this is your first journey with TH, then check out our [introduction to Template Haskell](https://serokell.io/blog/introduction-to-template-haskell) first.
 
@@ -68,7 +68,9 @@ SigE (LitE (IntegerL 42)) (ConT GHC.Base.String)
 
 ## Typed splices
 
-Just like we had untyped splices such as `$foo`, now we also have typed splices, written as `$$foo`. Note, however, that if your GHC version is below 9.0, you may need to write `$$(foo)` instead.
+Just like we had untyped splices such as `$foo`, now we also have typed splices, written as `$$foo`. In this section, we will see how to define and splice typed Template Haskell code.
+
+We reiterate one point mentioned in our previous article: in GHC 8, the usage of splices may require parentheses or not. For instance, if `foo` came from a qualified import, then you'd need to write `$$(Foo.foo)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
 
 ## Example: calculating prime numbers
 
@@ -267,7 +269,7 @@ Typed Template Haskell may have some difficulties resolving overloads. Surprisin
 ... mempty' = [|| mempty ||]
 
 >>> x :: String
-... x = id $$(mempty')
+... x = id $$mempty'
 <interactive>:549:11: error:
     • Ambiguous type variable ‘a0’ arising from a use of ‘mempty'’
       prevents the constraint ‘(Monoid a0)’ from being solved.
@@ -279,8 +281,8 @@ Typed Template Haskell may have some difficulties resolving overloads. Surprisin
         ...plus 7 others
         (use -fprint-potential-instances to see them all)
     • In the expression: mempty'
-      In the Template Haskell splice $$(mempty')
-      In the first argument of ‘id’, namely ‘$$(mempty')’
+      In the Template Haskell splice $$mempty'
+      In the first argument of ‘id’, namely ‘$$mempty'’
 ```
 
 Annotating `mempty'` may resolve it in this case:

--- a/Typed Template Haskell/article.md
+++ b/Typed Template Haskell/article.md
@@ -70,7 +70,7 @@ SigE (LitE (IntegerL 42)) (ConT GHC.Base.String)
 
 Just like we had untyped splices such as `$foo`, now we also have typed splices, written as `$$foo`. In this section, we will see how to define and splice typed Template Haskell code.
 
-We reiterate one point mentioned in our previous article: in GHC 8, the usage of splices may require parentheses or not. For instance, if `foo` came from a qualified import, then you'd need to write `$$(Foo.foo)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
+We reiterate one point mentioned in our previous article: before GHC 9, the usage of splices may require parentheses or not. For instance, if `foo` came from a qualified import, then you'd need to write `$$(Foo.foo)` instead. In GHC 9, the parser is more relaxed and will not require parentheses in such situations.
 
 ## Example: calculating prime numbers
 
@@ -330,7 +330,7 @@ Furthermore, as discussed, the [caveat](#caveat) in the previous section doesn't
 ""
 ```
 
-Should you need to explicitly convert between the old and new types, you may pattern match directly on `Code` or use the following functions:
+Should you need to explicitly convert between the old and new types, you may pattern match directly on `Code` or use the following functions from [Language.Haskell.TH](https://hackage.haskell.org/package/template-haskell-2.18.0.0/docs/Language-Haskell-TH.html#t:Code):
 
 ```hs
 liftCode :: m (TExp a) -> Code m a

--- a/Typed Template Haskell/article.md
+++ b/Typed Template Haskell/article.md
@@ -306,9 +306,9 @@ An [open ticket](https://gitlab.haskell.org/ghc/ghc/-/issues/10271) exists descr
 
 In GHC 9, the types used by typed Template Haskell were changed according to the [Make Q (TExp a) into a newtype](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0195-code-texp.rst) proposal.
 
-This proposal changed the typed expression quasi-quoter so it now returns `Quote m => Code m a` instead of the old `Quote m => m (TExp a)` from [`template-haskell-2.17.0.0`](https://hackage.haskell.org/package/template-haskell-2.17.0.0/docs/Language-Haskell-TH.html#t:Code).
+This proposal changed the typed expression quasi-quoter so it now returns `Quote m => Code m a` instead of the old `Q (TExp a)` which was used prior to GHC 9.
 
-If the reader is curious, please take a moment to read our [Typed Template Haskell in GHC 9](https://serokell.io/blog/typed-template-haskell-in-ghc-9) article detailing a migration guide of typed TH code to GHC 9, where we discuss a backward-compatible way to integrate typed Template Haskell code in both GHC 8 and GHC 9.
+If you're curious, please take a moment to read our [Typed Template Haskell in GHC 9](https://serokell.io/blog/typed-template-haskell-in-ghc-9) article detailing a migration guide of typed TH code to GHC 9, where we discuss a backward-compatible way of integrating typed Template Haskell code in both GHC 8 and GHC 9.
 
 Thankfully, changing the examples to work with GHC 9 is not difficult. In short, you may replace the parts like `Q (TExp a)` with `Quote m => Code m a` (or `Code Q a`) and the code should compile.
 

--- a/Typed Template Haskell/article.md
+++ b/Typed Template Haskell/article.md
@@ -306,7 +306,7 @@ An [open ticket](https://gitlab.haskell.org/ghc/ghc/-/issues/10271) exists descr
 
 In GHC 9, the types used by typed Template Haskell were changed according to the [Make Q (TExp a) into a newtype](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0195-code-texp.rst) proposal.
 
-This proposal changed the typed expression quasi-quoter so it now returns `Quote m => Code m a` instead of the old `Q (TExp a)` which was used prior to GHC 9.
+This proposal changed the typed expression quasi-quoter so it now returns `Quote m => Code m a` instead of the old `Q (TExp a)` which was used prior to GHC 9. Besides returing `Code m a` instead of `Q a`, the introduction of the `Quote` type class allows using an arbitrary type instead of the concrete `Q` from previous versions. Most of the times, `Code Q a` should suffice for your applications.
 
 If you're curious, please take a moment to read our [Typed Template Haskell in GHC 9](https://serokell.io/blog/typed-template-haskell-in-ghc-9) article detailing a migration guide of typed TH code to GHC 9, where we discuss a backward-compatible way of integrating typed Template Haskell code in both GHC 8 and GHC 9.
 

--- a/Typed Template Haskell/article.md
+++ b/Typed Template Haskell/article.md
@@ -308,9 +308,7 @@ In GHC 9, the types used by typed Template Haskell were changed according to the
 
 This proposal changed the typed expression quasi-quoter so it now returns `Quote m => Code m a` instead of the old `Quote m => m (TExp a)` from [`template-haskell-2.17.0.0`](https://hackage.haskell.org/package/template-haskell-2.17.0.0/docs/Language-Haskell-TH.html#t:Code).
 
-<!-- TODO: Write new article, add link to it, uncomment this part.
-If the reader is curious, please take a moment to read our []() article detailing a migration guide of typed TH code to GHC 9, where we discuss a backward-compatible way to integrate typed Template Haskell code in both GHC 8 and GHC 9.
--->
+If the reader is curious, please take a moment to read our [Typed Template Haskell in GHC 9](https://serokell.io/blog/typed-template-haskell-in-ghc-9) article detailing a migration guide of typed TH code to GHC 9, where we discuss a backward-compatible way to integrate typed Template Haskell code in both GHC 8 and GHC 9.
 
 Thankfully, changing the examples to work with GHC 9 is not difficult. In short, you may replace the parts like `Q (TExp a)` with `Quote m => Code m a` (or `Code Q a`) and the code should compile.
 

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -2,11 +2,11 @@
 
 Welcome to our third post about Template Haskell! 
 
-Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to write TTH code that will work with both GHC 8 and GHC 9.
+Today we will take a look at the changes that were made in GHC 9 regarding typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to write TTH code that will work with both GHC 8 and GHC 9.
 
-In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we gave an overview of Typed Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
+In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we gave an overview of typed Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
 
-## Changes in the Typed Template Haskell specification
+## Changes in the typed Template Haskell specification
 
 The `template-haskell` package was changed in version 2.17.0.0 and GHC version 9.0 according to the [Make Q (TExp a) into a newtype](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0195-code-texp.rst) proposal, in which the typed expression quasi-quoter (`[|| ... ||]`) now returns a different datatype.
 
@@ -192,7 +192,7 @@ Production
 
 ## Conclusion
 
-In this post, we've seen the changes introduced in GHC 9 regarding Typed Template Haskell. We've learned about two different ways to migrate typed Template Haskell code from GHC 8 to GHC 9 and analyzed their differences.
+In this post, we've seen the changes introduced in GHC 9 regarding typed Template Haskell. We've learned about two different ways to migrate typed Template Haskell code from GHC 8 to GHC 9 and analyzed their differences.
 
 Using `th-compat` has a big advantage in being compatible with various GHC versions, besides having an interface similar to the one in GHC 9. On the other hand, if supporting GHC 8 is not necessary, it becomes an extra dependency in your project that's potentially unfamiliar to many users. The choice of which strategy to use will ultimately depend on your specific needs, but we hope to have shed light on their pros and cons.
 

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -1,10 +1,12 @@
 # Typed Template Haskell in GHC 9
 
-Welcome to our third post about Template Haskell! Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to write TTH code that will work with both GHC 8 and GHC 9.
+Welcome to our third post about Template Haskell! 
+
+Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to write TTH code that will work with both GHC 8 and GHC 9.
 
 In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we gave an overview of Typed Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
 
-## Changed Typed Template Haskell specification
+## Changes in the Typed Template Haskell specification
 
 The `template-haskell` package was changed in version 2.17.0.0 and GHC version 9.0 according to the [Make Q (TExp a) into a newtype](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0195-code-texp.rst) proposal, in which the typed expression quasi-quoter (`[|| ... ||]`) now returns a different datatype.
 
@@ -25,13 +27,13 @@ newtype Code m (a :: TYPE (r :: RuntimeRep)) = Code
   }
 ```
 
-The differences between the simplified and real definitions are not important for the understanding of this post, and you may keep the simplified definition in mind while reading through this.
+The differences between the simplified and real definitions are not important for understanding this post, and you may keep the simplified definition in mind while reading through this.
 
 Thankfully, the untyped TH interface remains mostly unchanged, and the typed TH interface should only need to use `Code` instead of `TExp` to compile again with some helper functions.
 
-## Example GHC 8 code
+## GHC 8 code example
 
-To make the examples here easier to follow, let us define a small typed Template Haskell module that we wish to work under GHC 8, which we will later port to GHC 9. The code will be quite simple, its purpose is to parse an environment flag into a known data type or stop the compilation altogether if it fails.
+To make the examples here easier to follow, let us define a small typed Template Haskell module that we wish to work under GHC 8, which we will later port to GHC 9. The code will be quite simple: its purpose will be to parse an environment flag into a known data type or stop the compilation altogether if it fails.
 
 We will use the [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so don't forget to load it. You will also need to activate the `TemplateHaskell` language extension.
 
@@ -134,7 +136,7 @@ And that's it! If you want the code to still work on GHC 8, however, make sure t
 
 For this section, you may choose to use either GHC 8 or GHC 9. We will use the [`th-compat`](https://hackage.haskell.org/package/th-compat) package, besides the familiar [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so make sure you load them both.
 
-`th-compat` is our recommended library for backward compatibility with TTH. In this section, we will show how to change the usage from `Code` to the backward-compatible `Splice` which works on GHC 9 as well as previous versions.
+`th-compat` is our recommended library for backward compatibility with TTH. In this section, we will show how to change the usage from `Code` to the backward-compatible `Splice`, which works on GHC 9 as well as previous versions.
 
 The pattern is pretty similar to the workflow with `Code`, albeit with `Splice` now.
 
@@ -171,7 +173,7 @@ And that's it! `Splice m a` is defined in `th-compat` as `Code m a` in GHC 9 and
 
 ## Parentheses in splices
 
-Just one more thing before we conclude this article. You may see surprising behavior regarding the usage of parentheses in splices for both untyped and typed Template Haskell. The parser was tweaked in GHC 9 so parentheses are not necessary in some situations compared to prior versions.
+Just one more thing before we conclude this article. You may see surprising behavior regarding the usage of parentheses in splices for both untyped and typed Template Haskell. The parser was tweaked in GHC 9 so parentheses are unnecessary in some situations compared to prior versions.
 
 For example, if we had imported `logLevelFromFlag` qualified, then you'd write `$$(TH.logLevelFromFlag)` in GHC 8, otherwise you'd get a parser error:
 

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -20,7 +20,7 @@ newtype Code m (a :: TYPE (r :: RuntimeRep)) = Code
   }
 ```
 
-Thankfully, the untyped TH interface remains unchanged, and the typed TH interface should only need to use `Code` instead of `TExp` to compile again with some helper functions.
+Thankfully, the untyped TH interface remains mostly unchanged, and the typed TH interface should only need to use `Code` instead of `TExp` to compile again with some helper functions.
 
 <!-- TODO: Write about motivation as well? -->
 

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -189,7 +189,7 @@ For example, if we had imported `logLevelFromFlag` qualified, then you'd write `
 <interactive>:200:1: error: parse error on input ‘$$’
 ```
 
-But it works otherwise in GHC 9:
+But it works in GHC 9:
 
 ```hs
 >>> $$TH.logLevelFromFlag
@@ -198,8 +198,8 @@ Production
 
 ## Conclusion
 
-In this post, we've seen the changes introduced in GHC 9 regarding Typed Template Haskell. We learned about two different ways to migrate typed Template Haskell code from GHC 8 to GHC 9 and analyzed their differences.
+In this post, we've seen the changes introduced in GHC 9 regarding Typed Template Haskell. We've learned about two different ways to migrate typed Template Haskell code from GHC 8 to GHC 9 and analyzed their differences.
 
-Using `th-compat` has a big advantage in being compatible with two compilers, besides having an interface similar to the one in GHC 9. On the other hand, if supporting GHC 8 is not necessary, it becomes an extra dependency in your project, being potentially unfamiliar to many users. The choice of which strategy to use will ultimately depend on your specific needs, but we hope to have shed a light on their pros and cons.
+Using `th-compat` has a big advantage in being compatible with two compilers, besides having an interface similar to the one in GHC 9. On the other hand, if supporting GHC 8 is not necessary, it becomes an extra dependency in your project that's potentially unfamiliar to many users. The choice of which strategy to use will ultimately depend on your specific needs, but we hope to have shed light on their pros and cons.
 
-For more Haskell tutorials, you can check out our [Haskell articles](https://serokell.io/blog/haskell) or follow us on [Twitter](https://twitter.com/serokell) or [Medium](https://serokell.medium.com/).
+For more Haskell tutorials, you can check out our [Haskell articles](https://serokell.io/blog/haskell) or follow us on [Twitter](https://twitter.com/serokell) or [Dev](https://dev.to/serokell/).

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -1,0 +1,246 @@
+# Typed Template Haskell in GHC 9
+
+Welcome to our third post about Template Haskell! Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to make TTH code that will work with both GHC 8 and GHC 9.
+
+<!-- TODO: Actually amend the article! -->
+In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we made an overview of Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
+
+## Changed Typed Template Haskell specification
+
+The `template-haskell` package was changed in version 2.17.0.0 and GHC version 9.0 according to the [Make Q (TExp a) into a newtype](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0195-code-texp.rst) proposal, in which the typed expression quasi-quoter (`[|| ... ||]`) now returns a different datatype.
+
+Under the new specification, typed expressions now return `Quote m => Code m a` instead of `Q (TExp a)`. This is a breaking change for existing code, and codebases targetting GHC 9.0 either need to adapt their TTH code or use an alternative approach for compatibility.
+
+The `Code` newtype is simply a wrapper around an `m (TExp a)` (plus some levity-polymorphism mechanisms), defined as such:
+
+```hs
+type role Code representational nominal
+newtype Code m (a :: TYPE (r :: RuntimeRep)) = Code
+  { examineCode :: m (TExp a) -- ^ Underlying monadic value
+  }
+```
+
+Thankfully, the untyped TH interface remains unchanged, and the typed TH interface should only need to use `Code` instead of `TExp` to compile again with some helper functions.
+
+<!-- TODO: Write about motivation as well? -->
+
+## Example GHC 8 code
+
+To make the examples here easier to follow, let us define a small typed Template Haskell module that we wish to work under GHC 8. It will serve as a basis so we can migrate it to work under GHC 9.
+
+The code will be quite simple, its purpose is to parse an environment flag into a known data type or stop the compilation altogether if it fails.
+
+We will use the [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so don't forget to load it.
+
+You will also need to activate the `TemplateHaskell` language extension.
+
+```hs
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH where
+
+import Control.Monad.IO.Class (liftIO)
+import Language.Haskell.TH.Syntax (Q, TExp)
+import System.Environment (lookupEnv)
+
+data LogLevel
+  = Development  -- ^ Log errors and debug messages
+  | Production  -- ^ Only log errors
+  deriving (Show)
+
+logLevelFromFlag :: Q (TExp LogLevel)
+logLevelFromFlag = do
+  flag <- liftIO $ lookupEnv "LOG_LEVEL"
+  case flag of
+    Nothing -> [|| Production ||]  -- We default to Production if the flag is unset
+    Just level -> case level of
+      "DEVELOPMENT" -> [|| Development ||]
+      "PRODUCTION" -> [|| Production ||]
+      other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
+```
+
+You can now query it from GHCi. To test it, `System.Environment` also exports the `setEnv :: String -> String -> IO ()` and `unsetEnv :: String -> IO ()` functions.
+
+```hs
+>>> :l TH
+[1 of 1] Compiling TH               ( TH.hs, interpreted )
+Ok, one module loaded.
+
+>>> :set -XTemplateHaskell
+
+>>> $$logLevelFromFlag
+Production
+
+>>> import System.Environment
+
+>>> setEnv "LOG_LEVEL" "DEVELOPMENT"
+
+>>> $$logLevelFromFlag
+Development
+
+>>> setEnv "LOG_LEVEL" "TH"
+
+>>> $$logLevelFromFlag
+
+<interactive>:311:1: error:
+    • Unrecognized LOG_LEVEL flag: TH
+    • In the Template Haskell splice $$logLevelFromFlag
+      In the expression: $$logLevelFromFlag
+      In an equation for ‘it’: it = $$logLevelFromFlag
+```
+
+If you try to compile this module with GHC 9, however, this example will fail to compile:
+
+```hs
+>>> :l TH
+
+TH.hs:18:16: error:
+    • Couldn't match type ‘Code m0’ with ‘Q’
+      Expected: Q (TExp LogLevel)
+        Actual: Code m0 LogLevel
+    • In the Template Haskell quotation [|| Production ||]
+      In the expression: [|| Production ||]
+      In a case alternative: Nothing -> [|| Production ||]
+   |
+18 |     Nothing -> [|| Production ||]  -- We default to Production if the flag is unset
+   |                ^^^^^^^^^^^^^^^^^^
+
+TH.hs:20:24: error:
+    • Couldn't match type ‘Code m1’ with ‘Q’
+      Expected: Q (TExp LogLevel)
+        Actual: Code m1 LogLevel
+    • In the Template Haskell quotation [|| Development ||]
+      In the expression: [|| Development ||]
+      In a case alternative: "DEVELOPMENT" -> [|| Development ||]
+   |
+20 |       "DEVELOPMENT" -> [|| Development ||]
+   |                        ^^^^^^^^^^^^^^^^^^^
+
+TH.hs:21:23: error:
+    • Couldn't match type ‘Code m2’ with ‘Q’
+      Expected: Q (TExp LogLevel)
+        Actual: Code m2 LogLevel
+    • In the Template Haskell quotation [|| Production ||]
+      In the expression: [|| Production ||]
+      In a case alternative: "PRODUCTION" -> [|| Production ||]
+   |
+21 |       "PRODUCTION" -> [|| Production ||]
+   |                       ^^^^^^^^^^^^^^^^^^
+Failed, no modules loaded.
+```
+
+This is because the quasi-quoter now returns `Quote m => Code m LogLevel`.
+
+In the next sections, we will see how to port this code to GHC 9 without and with backward compatibility with GHC 8.
+
+## Porting old TTH code without backward compatibility
+
+For this section, you need a GHC whose version is at least 9. If you want your code to be compatible with both GHC 8 and GHC 9, please read [the next section](#porting-old-tth-code-with-backwards-compatibility) instead.
+
+Make sure to import the appropriate definitions from `template-haskell`:
+
+```hs
+import Language.Haskell.TH.Syntax (Code, Q, examineCode, liftCode)
+```
+
+Since we now need to return a value of type `Code`, we change our type signature. And now we can fix the code simply by using two new functions, namely `examineCode` and `liftCode`:
+
+```hs
+logLevelFromFlag :: Code Q LogLevel
+logLevelFromFlag = liftCode $ do  -- liftCode will turn 'Q' into 'Code'
+  flag <- liftIO $ lookupEnv "LOG_LEVEL"
+  case flag of
+    -- examineCode will turn 'Code' into 'Q'
+    Nothing -> examineCode [|| Production ||]  -- We default to Production if the flag is unset
+    Just level -> case level of
+      "DEVELOPMENT" -> examineCode [|| Development ||]
+      "PRODUCTION" -> examineCode [|| Production ||]
+      other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
+```
+
+The biggest problem here is the expectation that the quasi-quoter will return a `Code`. But at the same time, it has no `MonadIO`, `MonadFail` or `Quote` instances, preventing us from using `liftIO`, `fail`, and the quasi-quoter, which are provided by `Q`.
+
+That is what the errors were telling us in the previous section. The solution is to use `examineCode` to turn a `Code m a` into a `m (TExp a)`, and then `liftCode` to do the opposite operation: turning a `m (TExp a)` into a `Code m a`.
+
+```hs
+liftCode    :: forall (r :: RuntimeRep) (a :: TYPE r) m. m (TExp a) -> Code m a
+examineCode :: forall (r :: RuntimeRep) (a :: TYPE r) m. Code m a -> m (TExp a)
+```
+
+With it, our quasi-quoter result becomes in the expected format to run Template Haskell functions and then converted back into the type that the splice expects. The changes we made to the function are the general pattern you will use when exporting functions to be used by splices.
+
+Additionally, you can also make the type signature a bit more generic:
+
+```hs
+logLevelFromFlag :: (MonadIO m, MonadFail m, Quote m) => Code m LogLevel
+```
+
+If you are only interested in using `Q`, however, you can instead use `CodeQ`, which is simply `Code Q`:
+
+```hs
+import Language.Haskell.TH.Lib (CodeQ)
+```
+
+And then use it like so:
+
+```hs
+logLevelFromFlag :: CodeQ LogLevel
+```
+
+And that's it! If you want the code to still work on GHC 8, however, make sure to read the next section.
+
+## Porting old TTH code with backward compatibility
+
+For this section, you may choose to use either GHC 8 or GHC 9.
+
+We will use the [`th-compat`](https://hackage.haskell.org/package/th-compat) package, besides the familiar [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so make sure you load them.
+
+If you've read the previous section, you will see the pattern is pretty similar to the workflow with `Code`, albeit with `Splice` now.
+
+Make sure to import the appropriate definitions first:
+
+```hs
+import Language.Haskell.TH.Syntax (Q)
+import Language.Haskell.TH.Syntax.Compat (Splice, examineSplice, liftSplice)
+```
+
+And now just replace `Code` with `Splice`:
+
+```hs
+logLevelFromFlag :: Splice Q LogLevel
+logLevelFromFlag = liftSplice $ do  -- liftSplice will turn 'Q' into 'Splice'
+  flag <- liftIO $ lookupEnv "LOG_LEVEL"
+  case flag of
+    -- examineSplice will turn 'Splice' into 'Q'
+    Nothing -> examineSplice [|| Production ||]  -- We default to Production if the flag is unset
+    Just level -> case level of
+      "DEVELOPMENT" -> examineSplice [|| Development ||]
+      "PRODUCTION" -> examineSplice [|| Production ||]
+      other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
+```
+
+And that's it! `Splice m a` is defined in `th-compat` as `m (TExp a)` in GHC 8 and `Code m a` in GHC 9, and this is why this code works. In addition, functions like `liftSplice` and `examineSplice` will either be defined `liftCode` and `examineCode` (in GHC 9) or `id` (in GHC 8).
+
+If you wanted, you could drop your direct dependence on `template-haskell` here and simply use `th-compat`. You can use `SpliceQ` and avoid importing `Q` completely, similarly to `CodeQ`:
+
+```hs
+import Language.Haskell.TH.Syntax.Compat (SpliceQ, examineSplice, liftSplice)
+```
+
+And now use `SpliceQ` instead of `Splice`:
+
+```hs
+logLevelFromFlag :: SpliceQ LogLevel
+```
+
+This is because `SpliceQ` is defined simply as `Splice Q`.
+
+It's also possible to use `Quote m => Splice m a`, however, `Quote` was also introduced in a recent `template-haskell` version, so chances are it won't work in GHC 8 and it will be pointless from the point of view of backward compatibility. It can still be useful in other situations, however, like in combination with monad transformers (e.g.: `Splice (State Int Q) a`).
+
+## Conclusion
+
+In this post, we've seen the changes introduced in GHC 9 regarding Typed Template Haskell. We learned about two different ways to migrate typed Template Haskell code from GHC 8 to GHC 9 and analyzed their differences.
+
+Using `th-compat` has a big advantage in being compatible with two compilers, besides having an interface similar to the one in GHC 9. On the other hand, if supporting GHC 8 is not necessary, it becomes an extra dependency in your project, being potentially unfamiliar to many users. The choice of which strategy to use will ultimately depend on your specific needs, but we hope to have shed a light on their pros and cons.
+
+For more Haskell tutorials, you can check out our [Haskell articles](https://serokell.io/blog/haskell) or follow us on [Twitter](https://twitter.com/serokell) or [Medium](https://serokell.medium.com/).

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -177,7 +177,7 @@ Just one more thing before we conclude this article. You may see surprising beha
 
 For example, if we had imported `logLevelFromFlag` qualified, then you'd write `$$(TH.logLevelFromFlag)` in GHC 8, otherwise you'd get a parser error:
 
-```hs
+```none
 >>> $$TH.logLevelFromFlag
 
 <interactive>:200:1: error: parse error on input ‘$$’
@@ -185,7 +185,7 @@ For example, if we had imported `logLevelFromFlag` qualified, then you'd write `
 
 But it works in GHC 9:
 
-```hs
+```none
 >>> $$TH.logLevelFromFlag
 Production
 ```

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -62,36 +62,6 @@ logLevelFromFlag = do
       other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
 ```
 
-You can now query it from GHCi. To test it, `System.Environment` also exports the `setEnv :: String -> String -> IO ()` and `unsetEnv :: String -> IO ()` functions.
-
-```hs
->>> :l TH
-[1 of 1] Compiling TH               ( TH.hs, interpreted )
-Ok, one module loaded.
-
->>> :set -XTemplateHaskell
-
->>> $$logLevelFromFlag
-Production
-
->>> import System.Environment
-
->>> setEnv "LOG_LEVEL" "DEVELOPMENT"
-
->>> $$logLevelFromFlag
-Development
-
->>> setEnv "LOG_LEVEL" "TH"
-
->>> $$logLevelFromFlag
-
-<interactive>:311:1: error:
-    • Unrecognized LOG_LEVEL flag: TH
-    • In the Template Haskell splice $$logLevelFromFlag
-      In the expression: $$logLevelFromFlag
-      In an equation for ‘it’: it = $$logLevelFromFlag
-```
-
 If you try to compile this module with GHC 9, however, this example will fail to compile:
 
 ```hs

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -1,8 +1,8 @@
 # Typed Template Haskell in GHC 9
 
-Welcome to our third post about Template Haskell! Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to make TTH code that will work with both GHC 8 and GHC 9.
+Welcome to our third post about Template Haskell! Today we will take a look at the changes that were made in GHC 9 regarding Typed Template Haskell (TTH) and how to use the [`th-compat`](https://hackage.haskell.org/package/th-compat) library to write TTH code that will work with both GHC 8 and GHC 9.
 
-In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we made an overview of Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
+In our [previous blog post](https://serokell.io/blog/typed-template-haskell-overview), we gave an overview of Typed Template Haskell in GHC 8. The article was later amended with the changes required so that the examples compile in GHC 9 in a non-backward compatible way. Make sure to read that post before you continue!
 
 ## Changed Typed Template Haskell specification
 
@@ -102,7 +102,7 @@ TH.hs:21:23: error:
 Failed, no modules loaded.
 ```
 
-In the next sections, we will see how to port this code to GHC 9 without and with backward compatibility with GHC 8.
+In the following sections, we will see how to port this code to GHC 9 without and with backward compatibility with GHC 8.
 
 ## Porting old TTH code without backward compatibility
 
@@ -125,8 +125,8 @@ Since we now need to return a value of type `Code`, we change our type signature
 -    Nothing -> [|| Production ||]  -- We default to Production if the flag is unset
 +    Nothing -> examineCode [|| Production ||]  -- We default to Production if the flag is unset
     Just level -> case level of
-_      "DEVELOPMENT" -> [|| Development ||]
-_      "PRODUCTION" -> [|| Production ||]
+-      "DEVELOPMENT" -> [|| Development ||]
+-      "PRODUCTION" -> [|| Production ||]
 +      "DEVELOPMENT" -> examineCode [|| Development ||]
 +      "PRODUCTION" -> examineCode [|| Production ||]
       other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
@@ -143,7 +143,7 @@ And that's it! If you want the code to still work on GHC 8, however, make sure t
 
 ## Porting old TTH code with backward compatibility
 
-For this section, you may choose to use either GHC 8 or GHC 9. We will use the [`th-compat`](https://hackage.haskell.org/package/th-compat) package, besides the familiar [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so make sure you load them.
+For this section, you may choose to use either GHC 8 or GHC 9. We will use the [`th-compat`](https://hackage.haskell.org/package/th-compat) package, besides the familiar [`template-haskell`](https://hackage.haskell.org/package/template-haskell) package, so make sure you load them both.
 
 The pattern is pretty similar to the workflow with `Code`, albeit with `Splice` now.
 
@@ -175,7 +175,7 @@ And now just replace `Code` with `Splice`:
       other -> fail $ "Unrecognized LOG_LEVEL flag: " <> other
 ```
 
-And that's it! `Splice m a` is defined in `th-compat` as `m (TExp a)` in GHC 8 and `Code m a` in GHC 9, and this is why this code works. In addition, functions like `liftSplice` and `examineSplice` will either be defined `liftCode` and `examineCode` (in GHC 9) or `id` (in GHC 8).
+And that's it! `Splice m a` is defined in `th-compat` as `m (TExp a)` in GHC 8 and `Code m a` in GHC 9, and this is why this code works. In addition, functions like `liftSplice` and `examineSplice` will either be defined as `liftCode` and `examineCode` (in GHC 9) or `id` (in GHC 8).
 
 ## Parentheses in splices
 

--- a/typed-th-in-ghc-9/article.md
+++ b/typed-th-in-ghc-9/article.md
@@ -135,7 +135,7 @@ In the next sections, we will see how to port this code to GHC 9 without and wit
 
 ## Porting old TTH code without backward compatibility
 
-For this section, you need a GHC whose version is at least 9. If you want your code to be compatible with both GHC 8 and GHC 9, please read [the next section](#porting-old-tth-code-with-backwards-compatibility) instead.
+For this section, you need a GHC whose version is at least 9.
 
 Make sure to import the appropriate definitions from `template-haskell`:
 
@@ -236,6 +236,25 @@ logLevelFromFlag :: SpliceQ LogLevel
 This is because `SpliceQ` is defined simply as `Splice Q`.
 
 It's also possible to use `Quote m => Splice m a`, however, `Quote` was also introduced in a recent `template-haskell` version, so chances are it won't work in GHC 8 and it will be pointless from the point of view of backward compatibility. It can still be useful in other situations, however, like in combination with monad transformers (e.g.: `Splice (State Int Q) a`).
+
+## Parentheses in splices
+
+Just one more thing before we conclude this article. You may see surprising behavior regarding the usage of parentheses in splices for both untyped and typed Template Haskell depending on whether you are using GHC 8 or GHC 9.
+
+For example, if we had imported `logLevelFromFlag` qualified, then you'd write `$$(TH.logLevelFromFlag)` in GHC 8, otherwise you'd get a parser error:
+
+```hs
+>>> $$TH.logLevelFromFlag
+
+<interactive>:200:1: error: parse error on input ‘$$’
+```
+
+But it works otherwise in GHC 9:
+
+```hs
+$$TH.logLevelFromFlag
+Production
+```
 
 ## Conclusion
 


### PR DESCRIPTION
This PR introduces changes to our old Template Haskell articles so they work under GHC 9, as well as a new article describing the changes in the `Code` proposal and how to port existing TTH code from GHC 8 to GHC 9, in both non-compatible and compatible ways.